### PR TITLE
Reduce excessive memory allocations in parseNumber and formatNumber tags

### DIFF
--- a/impl/src/main/java/org/apache/taglibs/standard/tag/common/fmt/FormatNumberSupport.java
+++ b/impl/src/main/java/org/apache/taglibs/standard/tag/common/fmt/FormatNumberSupport.java
@@ -172,7 +172,7 @@ public abstract class FormatNumberSupport extends BodyTagSupport {
                 pageContext,
                 this,
                 true,
-                NumberFormat.getAvailableLocales());
+                SetLocaleSupport.numberLocales);
 
         if (loc != null) {
             // Create formatter

--- a/impl/src/main/java/org/apache/taglibs/standard/tag/common/fmt/ParseNumberSupport.java
+++ b/impl/src/main/java/org/apache/taglibs/standard/tag/common/fmt/ParseNumberSupport.java
@@ -132,7 +132,7 @@ public abstract class ParseNumberSupport extends BodyTagSupport {
                     pageContext,
                     this,
                     false,
-                    NumberFormat.getAvailableLocales());
+                    SetLocaleSupport.numberLocales);
         }
         if (loc == null) {
             throw new JspException(

--- a/impl/src/main/java/org/apache/taglibs/standard/tag/common/fmt/SetLocaleSupport.java
+++ b/impl/src/main/java/org/apache/taglibs/standard/tag/common/fmt/SetLocaleSupport.java
@@ -234,10 +234,18 @@ public abstract class SetLocaleSupport extends TagSupport {
      */
     static Locale[] availableFormattingLocales;
 
+    /**
+     * Setup the number formatting locales that will be used
+     * by {@link FormatNumberSupport#doEndTag()}
+     * and {@link ParseNumberSupport#doEndTag()}
+     * to prevent excessive memory allocations
+     */
+    static Locale[] numberLocales;
+
     static {
         Locale[] dateLocales = DateFormat.getAvailableLocales();
-        Locale[] numberLocales = NumberFormat.getAvailableLocales();
         List<Locale> locales = new ArrayList<Locale>(dateLocales.length);
+        numberLocales = NumberFormat.getAvailableLocales();
         for (Locale dateLocale : dateLocales) {
             for (Locale numberLocale : numberLocales) {
                 if (dateLocale.equals(numberLocale)) {


### PR DESCRIPTION
During profiling it appeared that _formatNumber_ tag  causes huge memory pressure which overwhelms GC resulting in overall application slowness.
![before](https://user-images.githubusercontent.com/722112/106400125-58202000-6425-11eb-9317-cf11c18e1780.png) 
|.| Before | After |
|-----------| ----------- |----------- |
| RPS |  578.0/s   |   707.7/s  |
| Avg Latency |  692 ms   |  561 ms  |

